### PR TITLE
Basic auth option and logging enhancement 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,46 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		
+		<!-- Logging support [Start] -->
+		<dependency>
+		    <groupId>org.springframework.boot</groupId>
+		    <artifactId>spring-boot-starter</artifactId>
+		    <exclusions>
+		        <exclusion>
+		            <groupId>org.springframework.boot</groupId>
+		            <artifactId>spring-boot-starter-logging</artifactId>
+		        </exclusion>
+		    </exclusions>
+		</dependency>
+		
+		<dependency>
+		    <groupId>org.springframework.boot</groupId>
+		    <artifactId>spring-boot-starter-log4j2</artifactId>
+		</dependency>
+		
+		<dependency>
+		    <groupId>org.apache.logging.log4j</groupId>
+		    <artifactId>log4j-web</artifactId>
+		</dependency>
+		
+		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-yaml</artifactId>
+		</dependency>
+
+	    <!-- Log4j2 Supports Async loggers. These loggers provide a drastic improvement 
+			in performance compared to their synchronous counterparts. 
+			Async Loggers internally use a library called Disruptor for asynchronous logging. 
+			Set the system property to use Async logger: log4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector 
+			java -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector -jar target/logging-log4j2-1.0.jar 
+		-->
+		<dependency>
+			<groupId>com.lmax</groupId>
+			<artifactId>disruptor</artifactId>
+			<version>3.4.2</version>
+		</dependency>
+		<!-- Logging support [End] -->
 	</dependencies>
 
 	<build>

--- a/src/main/java/org/alfresco/indexchecker/NodesCountComparator.java
+++ b/src/main/java/org/alfresco/indexchecker/NodesCountComparator.java
@@ -62,8 +62,7 @@ public class NodesCountComparator
                 List<Integer> solrIds = searchResponse.response.docs.stream().map(Doc::getDbid)
                         .collect(Collectors.toList());
 
-                if (solrIds.size() == 0)
-                {
+				if (solrIds != null && solrIds.size() == 0){
                     Integer maxDbId = dbClient.getMaxByType(alfrescoStoreId, uri, localName);
                     if (maxSolrDbId < maxDbId)
                     {

--- a/src/main/java/org/alfresco/indexchecker/NodesCountComparator.java
+++ b/src/main/java/org/alfresco/indexchecker/NodesCountComparator.java
@@ -61,8 +61,9 @@ public class NodesCountComparator
                         currentBatchId);
                 List<Integer> solrIds = searchResponse.response.docs.stream().map(Doc::getDbid)
                         .collect(Collectors.toList());
-
-				if (solrIds != null && solrIds.size() == 0){
+                
+                //Add a null check for solrIds to avoid NPE when solrIds comes as null from searchResponse
+                if (solrIds != null && solrIds.size() == 0){
                     Integer maxDbId = dbClient.getMaxByType(alfrescoStoreId, uri, localName);
                     if (maxSolrDbId < maxDbId)
                     {

--- a/src/main/java/org/alfresco/indexchecker/solr/SpringWebClient.java
+++ b/src/main/java/org/alfresco/indexchecker/solr/SpringWebClient.java
@@ -71,27 +71,26 @@ public class SpringWebClient
      * @param baseUrl Base URL for SOLR Server
      * @return Spring WebClient with applied configuration
      */
-    public WebClient getWebClient(String baseUrl) {
+	public WebClient getWebClient(String baseUrl) {
 
-        HttpClient httpClient = HttpClient.create(ConnectionProvider.create("web-client"));
+		HttpClient httpClient = HttpClient.create(ConnectionProvider.create("web-client"));
 
-        if (solrComms == CommMode.SECRET) {
-            httpClient = httpClient.headers(header -> {
-                header.add(HTTP_HEADER_SECRET, solrSecret);
-            });
-        }
-
-        if (solrComms == CommMode.HTTPS) {
-            httpClient = httpClient.secure(sslContextSpec -> sslContextSpec.sslContext(getMTLSContext()));
-        }
-
-        final Builder webClientBldr = WebClient.builder();	
-        if(solrComms == CommMode.NONE) {
-        	webClientBldr.defaultHeaders(header -> header.setBasicAuth(solrUser, solrPassword));
+		if (solrComms == CommMode.SECRET) {
+			httpClient = httpClient.headers(header -> {
+				header.add(HTTP_HEADER_SECRET, solrSecret);
+			});
 		}
-		return webClientBldr
-				.clientConnector(new ReactorClientHttpConnector(httpClient)).baseUrl(baseUrl).build();
-    }
+
+		if (solrComms == CommMode.HTTPS) {
+			httpClient = httpClient.secure(sslContextSpec -> sslContextSpec.sslContext(getMTLSContext()));
+		}
+
+		final Builder webClientBldr = WebClient.builder();
+		if (solrComms == CommMode.NONE) {
+			webClientBldr.defaultHeaders(header -> header.setBasicAuth(solrUser, solrPassword));
+		}
+		return webClientBldr.clientConnector(new ReactorClientHttpConnector(httpClient)).baseUrl(baseUrl).build();
+	}
 
     /**
      * Build SSLContext from keystores described in configuration

--- a/src/main/java/org/alfresco/indexchecker/solr/SpringWebClient.java
+++ b/src/main/java/org/alfresco/indexchecker/solr/SpringWebClient.java
@@ -1,19 +1,22 @@
 package org.alfresco.indexchecker.solr;
 
-import io.netty.handler.ssl.SslContext;
-import io.netty.handler.ssl.SslContextBuilder;
+import java.io.FileInputStream;
+import java.security.KeyStore;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Component;
 import org.springframework.util.ResourceUtils;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClient.Builder;
+
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import reactor.netty.http.client.HttpClient;
 import reactor.netty.resources.ConnectionProvider;
-
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.TrustManagerFactory;
-import java.io.FileInputStream;
-import java.security.KeyStore;
 
 /**
  * Spring Web Client includes specific configuration for all different
@@ -38,6 +41,12 @@ public class SpringWebClient
 
     @Value("${solr.secret}")
     String solrSecret;
+    
+    @Value("${solr.user}")
+    String solrUser;
+    
+    @Value("${solr.password}")
+    String solrPassword;
 
     @Value("${solr.mtls.keystore.path}")
     String keyStorePath;
@@ -76,11 +85,12 @@ public class SpringWebClient
             httpClient = httpClient.secure(sslContextSpec -> sslContextSpec.sslContext(getMTLSContext()));
         }
 
-        return WebClient
-                .builder()
-                .clientConnector(new ReactorClientHttpConnector(httpClient))
-                .baseUrl(baseUrl)
-                .build();
+        final Builder webClientBldr = WebClient.builder();	
+        if(solrComms == CommMode.NONE) {
+        	webClientBldr.defaultHeaders(header -> header.setBasicAuth(solrUser, solrPassword));
+		}
+		return webClientBldr
+				.clientConnector(new ReactorClientHttpConnector(httpClient)).baseUrl(baseUrl).build();
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,11 @@ solr.url=http://localhost:8983/solr
 solr.comms=NONE
 # Add secret word (only to be used for solr.comms=SECRET)
 solr.secret=
+
+#Basic auth properties in case you are using solr.comms=none with basic auth
+solr.user=
+solr.password=
+
 # mTLS / HTTPS keystores (only to be used for solr.comms=HTTPS)
 solr.mtls.keystore.path=
 solr.mtls.keystore.type=

--- a/src/main/resources/log4j2.yml
+++ b/src/main/resources/log4j2.yml
@@ -1,0 +1,36 @@
+Configuration:
+  status: info
+
+  appenders:
+    Console:
+      name: LogToConsole
+      PatternLayout:
+        Pattern: "[%-5level] %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %c{1} - %msg%n"
+
+    RollingFile:
+      - name: LogToRollingFile
+        fileName: logs/app.log
+        filePattern: "logs/$${date:yyyy-MM}/app-%d{MM-dd-yyyy}-%i.log.gz"
+        PatternLayout:
+          pattern: "%d{yyyy-MM-dd HH:mm:ss} %-5p [%c:%L] - %m%n"
+        Policies:
+          SizeBasedTriggeringPolicy:
+            size: 10MB
+        DefaultRollOverStrategy:
+          max: 10
+
+  Loggers:
+    logger:
+      - name: com.alfresco
+        level: debug
+        additivity: false
+        AppenderRef:
+          - ref: LogToConsole
+          - ref: LogToRollingFile
+
+    Root:
+      level: info
+      AppenderRef:
+        - ref: LogToConsole
+        - ref: LogToRollingFile
+        


### PR DESCRIPTION
This contains following fixes:

1- Added option to pass basic auth credentials in a setup where secure.comms is set as none and basic auth is set for solr admin. 2- Added a null check for solrIds
3- Added logging config to preserve the app logs for reference later as console logs gets wiped out on next run.